### PR TITLE
Fixed DDHidQueue to prevent mEventSource from leaking.

### DIFF
--- a/lib/DDHidQueue.m
+++ b/lib/DDHidQueue.m
@@ -120,6 +120,8 @@ static void queueCallbackFunction(void* target,  IOReturn result, void* refcon,
     CFRunLoopRemoveSource([mRunLoop getCFRunLoop], mEventSource, kCFRunLoopDefaultMode);
     (*mQueue)->stop(mQueue);
     [mRunLoop release];
+    CFRelease(mEventSource);
+    
     mRunLoop = nil;
     mStarted = NO;
 }


### PR DESCRIPTION
DDHidQueue's instance variable `mEventSource` is created using `createAsyncEventSource` (line **107**) in `startOnRunLoop:`. It is supposed to be released in `stop`, but never did and created leaks.
