### PR TITLE
DDHidQueue.m: Fix import case warning

### DIFF
--- a/lib/DDHidQueue.m
+++ b/lib/DDHidQueue.m
@@ -24,7 +24,7 @@
 
 #import "DDHidQueue.h"
 #import "DDHidElement.h"
-#import "DDHIdEvent.h"
+#import "DDHidEvent.h"
 #import "NSXReturnThrowError.h"
 
 static void queueCallbackFunction(void* target,  IOReturn result, void* refcon,


### PR DESCRIPTION
Was getting the following warning:

    DDHidLib/lib/DDHidQueue.m:27:9: warning: non-portable path
          to file '"DDHidEvent.h"'; specified path differs in case from file name on disk
          [-Wnonportable-include-path]
    #import "DDHIdEvent.h"
            ^~~~~~~~~~~~~~
            "DDHidEvent.h"
    1 warning generated.

This change corrects the case of the imported header file.